### PR TITLE
fix(elisp/org-pdf-export.el): update smart-quote following updates in org-8.3.2

### DIFF
--- a/elisp/org-pdf-export.el
+++ b/elisp/org-pdf-export.el
@@ -13,12 +13,12 @@
 (setq org-latex-listings 'minted)
 (setq org-export-with-smart-quotes t)
 (add-to-list 'org-export-smart-quotes-alist
-             '("en"
-               (opening-double-quote :utf-8 "“" :html "&ldquo;" :latex "\\enquote{" :texinfo "``")
-               (closing-double-quote :utf-8 "”" :html "&rdquo;" :latex "}" :texinfo "''")
-               (opening-single-quote :utf-8 "‘" :html "&lsquo;" :latex "\\enquote*{" :texinfo "`")
-               (closing-single-quote :utf-8 "’" :html "&rsquo;" :latex "}" :texinfo "'")
-               (apostrophe :utf-8 "’" :html "&rsquo;")))
+'("en"
+  (primary-opening :utf-8 "“" :html "&ldquo;" :latex "``" :texinfo "``")
+  (primary-closing :utf-8 "”" :html "&rdquo;" :latex "''" :texinfo "''")
+  (secondary-opening :utf-8 "‘" :html "&lsquo;" :latex "`" :texinfo "`")
+  (secondary-closing :utf-8 "’" :html "&rsquo;" :latex "'" :texinfo "'")
+  (apostrophe :utf-8 "’" :html "&rsquo;")))
 
 ;; Header.tex explicitly loads all necessary packages.
 (make-local-variable 'org-latex-default-packages-alist)


### PR DESCRIPTION
See: https://lists.nongnu.org/archive/html/emacs-orgmode/2015-10/msg00087.html