### PR TITLE
Fix paren typo

### DIFF
--- a/first_order_logic.rst
+++ b/first_order_logic.rst
@@ -50,7 +50,7 @@ Now, using the predicates and relation symbols, we can make assertions about the
 
 -  :math:`\mathit{even}(x + y + z)`
 -  :math:`\mathit{prime}((x + 1) \times y \times y)`
--  :math:`\mathit{square} (x + y \times z) = w)`
+-  :math:`\mathit{square}(x + y \times z) = w`
 -  :math:`x + y < z`
 
 Even more interestingly, we can use propositional connectives to build compound expressions like these:


### PR DESCRIPTION
To be honest I am not sure if the intention is `square(... = w)`, or `square(...) = 1`. I can see arguments for both, however I haven't read up to the equality relation yet, so if this is incorrect, I'll fix it up. Reason I went this route is because I assume `=` is not an assignment (hence the prose about it representing the equality relation), and I'm not sure how you'd square the result of an equality relation.