### PR TITLE
import data.nat

### DIFF
--- a/first_order_logic_in_lean.rst
+++ b/first_order_logic_in_lean.rst
@@ -205,7 +205,7 @@ In fact, all of the functions, predicates, and relations discussed here, except 
 
 .. code-block:: lean
 
-    import data.nat
+    import init.data.nat
     open nat
 
     constant square : ℕ → ℕ


### PR DESCRIPTION
not working in the default installation of Lean (version 3.4.2, Release).