### PR TITLE
fix the import statement

### DIFF
--- a/introduction.rst
+++ b/introduction.rst
@@ -177,7 +177,7 @@ Proofs in Lean can access a library of prior mathematical results, all verified 
 
 .. code-block:: lean
 
-  import data.nat.prime
+  import init.data.nat
   open nat
 
   theorem sqrt_two_irrational {a b : ℕ} (co : gcd a b = 1) :


### PR DESCRIPTION
but it does not make the proof valid. The symbols `dvd_of_dvd_pow`, `prime_two`, and `dvd_gcd` are missing in the current Lean 3.4.2 version.