### PR TITLE
Close HTML img tags

### DIFF
--- a/classical_reasoning.rst
+++ b/classical_reasoning.rst
@@ -16,7 +16,7 @@ Remember that in natural deduction, proof by contradiction is expressed by the f
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.1.png">
+   <img src="_static/classical_reasoning.1.png"/>
 
 .. raw:: latex
 
@@ -53,7 +53,7 @@ Here is a proof of ``em``, in natural deduction, using proof by contradiction:
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.3.png">
+   <img src="_static/classical_reasoning.3.png"/>
 
 .. raw:: latex
 
@@ -122,7 +122,7 @@ Proof by contradiction is also equivalent to the principle :math:`¬ ¬ A ↔ A`
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.4.png">
+   <img src="_static/classical_reasoning.4.png"/>
 
 .. raw:: latex
 
@@ -182,7 +182,7 @@ If :math:`A \to B` is any implication, the assertion :math:`\neg B \to \neg A` i
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.5.png">
+   <img src="_static/classical_reasoning.5.png"/>
 
 .. raw:: latex
 
@@ -207,7 +207,7 @@ Here is another example. Intuitively, asserting "if A then B" is equivalent to s
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.6.png">
+   <img src="_static/classical_reasoning.6.png"/>
 
 .. raw:: latex
 
@@ -262,7 +262,7 @@ Knowing that we can prove the law of the excluded middle, it is convenient to us
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.6bis.png">
+   <img src="_static/classical_reasoning.6bis.png"/>
 
 .. raw:: latex
 
@@ -333,7 +333,7 @@ Using these identities, we can always push negations down to propositional varia
 
 .. raw:: html
 
-   <img src="_static/classical_reasoning.8.png">
+   <img src="_static/classical_reasoning.8.png"/>
 
 .. raw:: latex
 

--- a/combinatorics.rst
+++ b/combinatorics.rst
@@ -284,7 +284,7 @@ For every :math:`n`, we know :math:`\binom{n}{0} = \binom{n}{n} = 1`. The previo
 
 .. raw:: html
 
-   <img src="_static/combinatorics.1.png">
+   <img src="_static/combinatorics.1.png"/>
 
 .. raw:: latex
 

--- a/first_order_logic.rst
+++ b/first_order_logic.rst
@@ -111,7 +111,7 @@ What we are really doing is proving that the universal statement holds, by showi
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.3.png">
+   <img src="_static/first_order_logic.3.png"/>
 
 .. raw:: latex
 
@@ -143,7 +143,7 @@ This example motivates the following rule in natural deduction:
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.4.png">
+   <img src="_static/first_order_logic.4.png"/>
 
 .. raw:: latex
 
@@ -158,7 +158,7 @@ What about the elimination rule? Suppose we know that every number is even or od
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.5.png">
+   <img src="_static/first_order_logic.5.png"/>
 
 .. raw:: latex
 
@@ -196,7 +196,7 @@ In a natural deduction proof this would look like this:
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.6.png">
+   <img src="_static/first_order_logic.6.png"/>
 
 .. raw:: latex
 
@@ -212,7 +212,7 @@ This illustrates the introduction rule for the existential quantifier:
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.7.png">
+   <img src="_static/first_order_logic.7.png"/>
 
 .. raw:: latex
 
@@ -238,7 +238,7 @@ In natural deduction, the elimination rule is expressed as follows:
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.8.png">
+   <img src="_static/first_order_logic.8.png"/>
 
 .. raw:: latex
 
@@ -330,7 +330,7 @@ We already adopted a similar convention for formulas: if we introduce a formula 
 
 .. raw:: html
 
-   <img src="_static/first_order_logic.10.png">
+   <img src="_static/first_order_logic.10.png"/>
 
 .. raw:: latex
 

--- a/first_order_logic_in_lean.rst
+++ b/first_order_logic_in_lean.rst
@@ -358,7 +358,7 @@ In the last chapter, we considered the following proof in natural deduction:
 
 .. raw:: html
 
-   <img src="_static/first_order_logic_in_lean.1.png">
+   <img src="_static/first_order_logic_in_lean.1.png"/>
 
 .. raw:: latex
 
@@ -508,7 +508,7 @@ In the last chapter, we considered the following natural deduction proof:
 
 .. raw:: html
 
-   <img src="_static/first_order_logic_in_lean.2.png">
+   <img src="_static/first_order_logic_in_lean.2.png"/>
 
 .. raw:: latex
 

--- a/inference_rules_for_first_order_logic.rst
+++ b/inference_rules_for_first_order_logic.rst
@@ -3,7 +3,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.1.png">
+   <img src="_static/natural_deduction_for_first_order_logic.1.png"/>
 
 .. raw:: latex
 
@@ -25,7 +25,7 @@ In the introduction rule, :math:`x` should not be free in any uncanceled hypothe
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.2.png">
+   <img src="_static/natural_deduction_for_first_order_logic.2.png"/>
 
 .. raw:: latex
 
@@ -54,7 +54,7 @@ In the introduction rule, :math:`t` can be any term that does not clash with any
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.3.png">
+   <img src="_static/natural_deduction_for_first_order_logic.3.png"/>
 
 .. raw:: latex
 

--- a/inference_rules_for_propositional_logic.rst
+++ b/inference_rules_for_propositional_logic.rst
@@ -3,7 +3,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.8.png">
+   <img src="_static/natural_deduction_for_propositional_logic.8.png"/>
 
 .. raw:: latex
 
@@ -30,7 +30,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.9.png">
+   <img src="_static/natural_deduction_for_propositional_logic.9.png"/>
 
 .. raw:: latex
 
@@ -56,7 +56,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.10.png">
+   <img src="_static/natural_deduction_for_propositional_logic.10.png"/>
 
 .. raw:: latex
 
@@ -83,7 +83,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.11.png">
+   <img src="_static/natural_deduction_for_propositional_logic.11.png"/>
 
 .. raw:: latex
 
@@ -122,7 +122,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.12.png">
+   <img src="_static/natural_deduction_for_propositional_logic.12.png"/>
 
 .. raw:: latex
 
@@ -142,7 +142,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.13.png">
+   <img src="_static/natural_deduction_for_propositional_logic.13.png"/>
 
 .. raw:: latex
 
@@ -181,7 +181,7 @@
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.14.png">
+   <img src="_static/natural_deduction_for_propositional_logic.14.png"/>
 
 .. raw:: latex
 

--- a/introduction.rst
+++ b/introduction.rst
@@ -101,7 +101,7 @@ symbol can be expressed as follows:
 
 .. raw:: html 
 
-   <img src="_static/introduction.1.png">
+   <img src="_static/introduction.1.png"/>
 
 .. raw:: latex
 
@@ -118,7 +118,7 @@ We will see that one can write such proofs more compactly leaving the hypotheses
 
 .. raw:: html 
 
-   <img src="_static/introduction.2.png">
+   <img src="_static/introduction.2.png"/>
 
 .. raw:: latex
 
@@ -132,7 +132,7 @@ In this format, a snippet of the first proof in the previous section might be re
 
 .. raw:: html 
 
-   <img src="_static/introduction.3.png">
+   <img src="_static/introduction.3.png"/>
 
 .. raw:: latex
 

--- a/natural_deduction_for_first_order_logic.rst
+++ b/natural_deduction_for_first_order_logic.rst
@@ -15,7 +15,7 @@ The following example of a proof in natural deduction shows that if, for every :
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.4.png">
+   <img src="_static/natural_deduction_for_first_order_logic.4.png"/>
 
 .. raw:: latex
 
@@ -42,7 +42,7 @@ Here is another example:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.5.png">
+   <img src="_static/natural_deduction_for_first_order_logic.5.png"/>
 
 .. raw:: latex
 
@@ -82,7 +82,7 @@ Then we can go on to derive :math:`\forall n \; (\mathit{even}(n) \vee \mathit{o
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.6.png">
+   <img src="_static/natural_deduction_for_first_order_logic.6.png"/>
 
 .. raw:: latex
 
@@ -110,7 +110,7 @@ We can also prove and :math:`\forall n \; \neg (\mathit{even}(n) \wedge \mathit{
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.7.png">
+   <img src="_static/natural_deduction_for_first_order_logic.7.png"/>
 
 .. raw:: latex
 
@@ -141,7 +141,7 @@ Remember that the intuition behind the elimination rule for the existential quan
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.8.png">
+   <img src="_static/natural_deduction_for_first_order_logic.8.png"/>
 
 .. raw:: latex
 
@@ -164,7 +164,7 @@ The following proof shows that if there is something satisfying either :math:`A`
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.9.png">
+   <img src="_static/natural_deduction_for_first_order_logic.9.png"/>
 
 .. raw:: latex
 
@@ -197,7 +197,7 @@ The following example is more involved:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.10.png">
+   <img src="_static/natural_deduction_for_first_order_logic.10.png"/>
 
 .. raw:: latex
 
@@ -233,7 +233,7 @@ Another example is that if :math:`x` does not occur in :math:`P`, then :math:`\e
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.11.png">
+   <img src="_static/natural_deduction_for_first_order_logic.11.png"/>
 
 .. raw:: latex
 
@@ -265,7 +265,7 @@ Recall the natural deduction rules for equality:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.12.png">
+   <img src="_static/natural_deduction_for_first_order_logic.12.png"/>
 
 .. raw:: latex
 
@@ -298,7 +298,7 @@ Keep in mind that we have implicitly fixed some first-order language, and :math:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.13.png">
+   <img src="_static/natural_deduction_for_first_order_logic.13.png"/>
 
 .. raw:: latex
 
@@ -312,7 +312,7 @@ The second axiom on that line is similar, except now :math:`P(x)` stands for any
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.13a.png">
+   <img src="_static/natural_deduction_for_first_order_logic.13a.png"/>
 
 .. raw:: latex
 
@@ -329,7 +329,7 @@ In fact, we can think of the first inference on the second line as a special cas
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.14.png">
+   <img src="_static/natural_deduction_for_first_order_logic.14.png"/>
 
 .. raw:: latex
 
@@ -361,7 +361,7 @@ The strategy is to use the elimination rule for the universal quantifier to inst
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.15.png">
+   <img src="_static/natural_deduction_for_first_order_logic.15.png"/>
 
 .. raw:: latex
 
@@ -397,7 +397,7 @@ More generally, given a formula :math:`\forall x \; A(x)`, a counterexample is a
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.16.png">
+   <img src="_static/natural_deduction_for_first_order_logic.16.png"/>
 
 .. raw:: latex
 

--- a/natural_deduction_for_propositional_logic.rst
+++ b/natural_deduction_for_propositional_logic.rst
@@ -18,7 +18,7 @@ Like formulas, proofs are built by putting together smaller proofs, according to
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.1.png">
+   <img src="_static/natural_deduction_for_propositional_logic.1.png"/>
 
 .. raw:: latex
 
@@ -33,7 +33,7 @@ is as follows: if you have a proof :math:`P_1` of :math:`A` from some hypotheses
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.2.png">
+   <img src="_static/natural_deduction_for_propositional_logic.2.png"/>
 
 .. raw:: latex
 
@@ -54,7 +54,7 @@ One thing that makes natural deduction confusing is that when you put together p
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.3.png">
+   <img src="_static/natural_deduction_for_propositional_logic.3.png"/>
 
 .. raw:: latex
 
@@ -79,7 +79,7 @@ We can continue to cancel the hypothesis :math:`A`:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.4.png">
+   <img src="_static/natural_deduction_for_propositional_logic.4.png"/>
 
 .. raw:: latex
 
@@ -108,7 +108,7 @@ The result is a proof using only the hypothesis :math:`C`. We can continue to ca
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.5.png">
+   <img src="_static/natural_deduction_for_propositional_logic.5.png"/>
 
 .. raw:: latex
 
@@ -143,7 +143,7 @@ Notice that in the second step, we canceled two "copies" of the hypothesis :math
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.6.png">
+   <img src="_static/natural_deduction_for_propositional_logic.6.png"/>
 
 .. raw:: latex
 
@@ -161,7 +161,7 @@ Finally, notice also that in these examples, we have assumed a special rule as t
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.7.png">
+   <img src="_static/natural_deduction_for_propositional_logic.7.png"/>
 
 .. raw:: latex
 
@@ -185,7 +185,7 @@ The following is a proof of :math:`A \to C` from :math:`A \to B` and :math:`B \t
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.15.png">
+   <img src="_static/natural_deduction_for_propositional_logic.15.png"/>
 
 .. raw:: latex
 
@@ -212,7 +212,7 @@ Intuitively, the formula
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.16.png">
+   <img src="_static/natural_deduction_for_propositional_logic.16.png"/>
 
 .. raw:: latex
 
@@ -241,7 +241,7 @@ The next proof shows that if a conclusion, :math:`C`, follows from :math:`A` and
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.17.png">
+   <img src="_static/natural_deduction_for_propositional_logic.17.png"/>
 
 .. raw:: latex
 
@@ -271,7 +271,7 @@ The conclusion of the next proof can be interpreted as saying that if it is not 
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.19.png">
+   <img src="_static/natural_deduction_for_propositional_logic.19.png"/>
 
 .. raw:: latex
 
@@ -306,7 +306,7 @@ Finally, the next two examples illustrate the use of the *ex falso* rule. The fi
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.20.png">
+   <img src="_static/natural_deduction_for_propositional_logic.20.png"/>
 
 .. raw:: latex
 
@@ -322,7 +322,7 @@ The second shows that :math:`B` follows from :math:`A` and :math:`\neg A \vee B`
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.21.png">
+   <img src="_static/natural_deduction_for_propositional_logic.21.png"/>
 
 .. raw:: latex
 
@@ -357,7 +357,7 @@ In the "official" description, natural deduction proofs are constructed by putti
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.22.png">
+   <img src="_static/natural_deduction_for_propositional_logic.22.png"/>
 
 .. raw:: latex
 
@@ -375,7 +375,7 @@ Then we use these two proofs to construct the following one:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.23.png">
+   <img src="_static/natural_deduction_for_propositional_logic.23.png"/>
 
 .. raw:: latex
 
@@ -392,7 +392,7 @@ Finally, we apply the implies-introduction rule to this proof to cancel the hypo
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.24.png">
+   <img src="_static/natural_deduction_for_propositional_logic.24.png"/>
 
 .. raw:: latex
 
@@ -483,7 +483,7 @@ The natural deduction proof looks as follows:
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.25.png">
+   <img src="_static/natural_deduction_for_propositional_logic.25.png"/>
 
 .. raw:: latex
 
@@ -512,7 +512,7 @@ For another example, here is a proof of :math:`A \wedge (B \vee C) \to (A \wedge
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_propositional_logic.18.png">
+   <img src="_static/natural_deduction_for_propositional_logic.18.png"/>
 
 .. raw:: latex
 

--- a/propositional_logic.rst
+++ b/propositional_logic.rst
@@ -58,7 +58,7 @@ Our goal is to give an account of the patterns of inference that govern the use 
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.1.png">
+   <img src="_static/propositional_logic.1.png"/>
 
 .. raw:: latex
 
@@ -93,7 +93,7 @@ This rule is sometimes known as *modus ponens*, or "implication elimination," si
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.2.png">
+   <img src="_static/propositional_logic.2.png"/>
 
 .. raw:: latex
 
@@ -127,7 +127,7 @@ This is a form of *hypothetical reasoning*. On the supposition that :math:`A` ho
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.3.png">
+   <img src="_static/propositional_logic.3.png"/>
 
 .. raw:: latex
 
@@ -167,7 +167,7 @@ The inference seems almost too obvious to state explicitly, since the word "and"
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.4.png">
+   <img src="_static/propositional_logic.4.png"/>
 
 .. raw:: latex
 
@@ -203,7 +203,7 @@ In symbols, these patterns are rendered as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.5.png">
+   <img src="_static/propositional_logic.5.png"/>
 
 .. raw:: latex
 
@@ -242,7 +242,7 @@ This is another form of hypothetical reasoning, similar to that used in establis
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.6.png">
+   <img src="_static/propositional_logic.6.png"/>
 
 .. raw:: latex
 
@@ -277,7 +277,7 @@ In symbolic logic, the rule of inference is expressed as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.7.png">
+   <img src="_static/propositional_logic.7.png"/>
 
 .. raw:: latex
 
@@ -295,7 +295,7 @@ What are the rules governing :math:`\bot`? In the proof system we will introduce
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.8.png">
+   <img src="_static/propositional_logic.8.png"/>
 
 .. raw:: latex
 
@@ -333,7 +333,7 @@ Having introduced a symbol for "false," it is only fair to introduce a symbol fo
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.8b.png">
+   <img src="_static/propositional_logic.8b.png"/>
 
 .. raw:: latex
 
@@ -361,7 +361,7 @@ In symbolic terms, the two introduction rules are as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.9.png">
+   <img src="_static/propositional_logic.9.png"/>
 
 .. raw:: latex
 
@@ -397,7 +397,7 @@ In symbols, this pattern is expressed as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.10.png">
+   <img src="_static/propositional_logic.10.png"/>
 
 .. raw:: latex
 
@@ -441,7 +441,7 @@ In symbols, we would render this rule as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.11.png">
+   <img src="_static/propositional_logic.11.png"/>
 
 .. raw:: latex
 
@@ -485,7 +485,7 @@ The introduction is modeled in natural deduction as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.12.png">
+   <img src="_static/propositional_logic.12.png"/>
 
 .. raw:: latex
 
@@ -537,7 +537,7 @@ Rendered in natural deduction, the rules are as follows:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.13.png">
+   <img src="_static/propositional_logic.13.png"/>
 
 .. raw:: latex
 
@@ -596,7 +596,7 @@ In natural deduction, proof by contradiction is expressed by the following patte
 
 .. raw:: html
 
-   <img src="_static/propositional_logic.14.png">
+   <img src="_static/propositional_logic.14.png"/>
 
 .. raw:: latex
 

--- a/propositional_logic_in_lean.rst
+++ b/propositional_logic_in_lean.rst
@@ -63,7 +63,7 @@ Formally, what is going on is that any proposition can be viewed as a type, name
 
 .. raw:: html
 
-   <img src="_static/propositional_logic_in_lean.1.png">
+   <img src="_static/propositional_logic_in_lean.1.png"/>
 
 .. raw:: latex
 
@@ -93,7 +93,7 @@ The two expressions represent, respectively, these two proofs:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic_in_lean.2.png">
+   <img src="_static/propositional_logic_in_lean.2.png"/>
 
 .. raw:: latex
 
@@ -126,7 +126,7 @@ This corresponds to the following proof:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic_in_lean.2b.png">
+   <img src="_static/propositional_logic_in_lean.2b.png"/>
 
 .. raw:: latex
 
@@ -515,7 +515,7 @@ In the last chapter, we constructed the following proof of :math:`A \to C` from 
 
 .. raw:: html
 
-   <img src="_static/propositional_logic_in_lean.3.png">
+   <img src="_static/propositional_logic_in_lean.3.png"/>
 
 .. raw:: latex
 
@@ -551,7 +551,7 @@ We also constructed the following proof:
 
 .. raw:: html
 
-   <img src="_static/propositional_logic_in_lean.4.png">
+   <img src="_static/propositional_logic_in_lean.4.png"/>
 
 .. raw:: latex
 
@@ -591,7 +591,7 @@ Finally, we constructed the following proof of :math:`A \wedge (B \vee C) \to (A
 
 .. raw:: html
 
-   <img src="_static/propositional_logic_in_lean.5.png">
+   <img src="_static/propositional_logic_in_lean.5.png"/>
 
 .. raw:: latex
 

--- a/semantics_of_propositional_logic.rst
+++ b/semantics_of_propositional_logic.rst
@@ -78,7 +78,7 @@ Let us motivate the semantics for material implication another way, using the de
 
 .. raw:: html
 
-   <img src="_static/semantics_of_propositional_logic.1.png">
+   <img src="_static/semantics_of_propositional_logic.1.png"/>
 
 .. raw:: latex
 
@@ -102,7 +102,7 @@ Similarly, if :math:`A` is false, we can prove :math:`A \to B` without any assum
 
 .. raw:: html
 
-   <img src="_static/semantics_of_propositional_logic.2.png">
+   <img src="_static/semantics_of_propositional_logic.2.png"/>
 
 .. raw:: latex
 
@@ -131,7 +131,7 @@ Finally, if :math:`A` is true and :math:`B` is false, we can prove :math:`\neg (
 
 .. raw:: html
 
-   <img src="_static/semantics_of_propositional_logic.3.png">
+   <img src="_static/semantics_of_propositional_logic.3.png"/>
 
 .. raw:: latex
 
@@ -196,7 +196,7 @@ To begin with, truth tables can be used to concisely summarize the semantics of 
 
 .. raw:: html
 
-   <img src="_static/semantics_of_propositional_logic.4.png">
+   <img src="_static/semantics_of_propositional_logic.4.png"/>
 
 .. raw:: latex
 
@@ -235,7 +235,7 @@ For compound formulas, the style is much the same. Sometimes it can be helpful t
 
 .. raw:: html
 
-   <img src="_static/semantics_of_propositional_logic.5.png">
+   <img src="_static/semantics_of_propositional_logic.5.png"/>
 
 .. raw:: latex
 

--- a/sets.rst
+++ b/sets.rst
@@ -116,7 +116,7 @@ Modulo the unfolding of definition of intersection and union in terms of "and" a
 
 .. raw:: html
 
-   <img src="_static/natural_deduction_for_first_order_logic.1.png">
+   <img src="_static/natural_deduction_for_first_order_logic.1.png"/>
 
 .. raw:: latex
 

--- a/the_natural_numbers_and_induction.rst
+++ b/the_natural_numbers_and_induction.rst
@@ -77,7 +77,7 @@ The pattern for a proof by induction is expressed even more naturally by the fol
 
 .. raw:: html
 
-   <img src="_static/the_natural_numbers_and_induction.1.png">
+   <img src="_static/the_natural_numbers_and_induction.1.png"/>
 
 .. raw:: latex
 


### PR DESCRIPTION
When building the epub version, I get errors related to non closed HTML tags.
This should help drive https://github.com/leanprover/logic_and_proof/issues/30 to resolution