### PR TITLE
Apply quantifier to term with free variable.

### DIFF
--- a/natural_deduction_for_first_order_logic.rst
+++ b/natural_deduction_for_first_order_logic.rst
@@ -465,7 +465,7 @@ For reference, here is a list of valid sentences involving quantifiers:
 -  :math:`\forall x \; (A(x) \to B) \leftrightarrow (\exists x \; A(x) \to B)` if :math:`x` is not free in :math:`B`
 -  :math:`\exists x \; (A(x) \to B) \leftrightarrow (\forall x \; A(x) \to B)` if :math:`x` is not free in :math:`B`
 -  :math:`\forall x \; (A \to B(x)) \leftrightarrow (A \to \forall x \; B(x))` if :math:`x` is not free in :math:`A`
--  :math:`\exists x \; (A(x) \to B) \leftrightarrow (A(x) \to \exists \; x B)` if :math:`x` is not free in :math:`B`
+-  :math:`\exists x \; (A(x) \to B) \leftrightarrow (\exists x \; A(x) \to B)` if :math:`x` is not free in :math:`B`
 -  :math:`\exists x \; A(x) \leftrightarrow \neg \forall x \; \neg A(x)`
 -  :math:`\forall x \; A(x) \leftrightarrow \neg \exists x \; \neg A(x)`
 -  :math:`\neg \exists x \; A(x) \leftrightarrow \forall x \; \neg A(x)`


### PR DESCRIPTION
Looks like the quantifier was on the wrong term (or I'm really confused.)  In the existing, x in A(x) is free; that's not the case for any other examples in this section.  Also, in the existing, Exists x B quantifies over a term that doesn't have x free.  Again, none of the other examples in this section have that.