### PR TITLE
fix build issue #50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export PATH := $(VENVDIR)/bin:$(PATH)
 
 install-deps:
 	test -f $(VENVDIR)/bin/pip || python3 -m venv $(VENVDIR)
-	pip install https://bitbucket.org/gebner/pygments-main/get/default.tar.gz#egg=Pygments
+	pip install pygments
 	pip install 'wheel>=0.29' # needed for old ubuntu versions, https://github.com/pallets/markupsafe/issues/59
 	pip install sphinx
 .PHONY: help Makefile

--- a/lean_sphinx.py
+++ b/lean_sphinx.py
@@ -1,7 +1,7 @@
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from sphinx.builders import Builder
-from sphinx.directives import CodeBlock
+from sphinx.directives.code import CodeBlock
 from sphinx.errors import SphinxError
 import os, os.path, fnmatch, subprocess
 import codecs


### PR DESCRIPTION
I merely tested that the build succeeded, but haven't gone over the output yet.

About the change to `sphinx.directives.CodeBlock`, we can see in the following commit that it appears to have been deprecated in favor of `sphinx.directives.code.CodeBlock` and then subsequently removed in a new version.

https://github.com/sphinx-doc/sphinx/commit/00002397764b391b0ebf737bbe47202ed4c98fff